### PR TITLE
추가 기능 7) 답변 페이징, 정렬 기능

### DIFF
--- a/src/main/java/com/ll/spring_additional/base/initData/NotProd.java
+++ b/src/main/java/com/ll/spring_additional/base/initData/NotProd.java
@@ -1,5 +1,8 @@
 package com.ll.spring_additional.base.initData;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,8 +11,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.spring_additional.boundedContext.answer.entity.Answer;
+import com.ll.spring_additional.boundedContext.answer.repository.AnswerRepository;
 import com.ll.spring_additional.boundedContext.answer.service.AnswerService;
 import com.ll.spring_additional.boundedContext.question.entity.Question;
+import com.ll.spring_additional.boundedContext.question.repository.QuestionRepository;
 import com.ll.spring_additional.boundedContext.question.service.QuestionService;
 import com.ll.spring_additional.boundedContext.user.entity.SiteUser;
 import com.ll.spring_additional.boundedContext.user.service.UserService;
@@ -22,7 +27,9 @@ public class NotProd {
 		PasswordEncoder passwordEncoder,
 		QuestionService questionService,
 		UserService userService,
-		AnswerService answerService
+		AnswerService answerService,
+		QuestionRepository questionRepository,
+		AnswerRepository answerRepository
 	)
 	{
 		return new CommandLineRunner() {
@@ -30,17 +37,23 @@ public class NotProd {
 			@Transactional
 			public void run(String... args) throws Exception {
 
-				userService.create("admin","admin@test.com", "1234");
+				userService.create("admin","admin@test.com", passwordEncoder.encode("1234"));
 
-				SiteUser user1 = userService.create("user1", "user1@test.com", "1234");
-				SiteUser user2 = userService.create("user2", "user2@test.com", "1234");
-				SiteUser user3 = userService.create("puar12", "r4560798@naver.com", "1234");
+				SiteUser user1 = userService.create("user1", "user1@test.com", passwordEncoder.encode("1234"));
+				SiteUser user2 = userService.create("user2", "user2@test.com", passwordEncoder.encode("1234"));
+				SiteUser user3 = userService.create("puar12", "r4560798@naver.com", passwordEncoder.encode("1234"));
+
+				List<Question> list = new ArrayList<>();
 
 				for (int i = 1; i <= 300; i++) {
-						String subject = String.format("테스트 데이터입니다:[%03d]", i);
-						String content = "내용무";
-						questionService.create(subject, content, user1, 0);
-					}
+					Question tmp = new Question();
+					tmp.setSubject(String.format("테스트 데이터입니다:[%03d]", i));
+					tmp.setContent("내용무");
+					tmp.setAuthor(user2);
+					list.add(tmp);
+				}
+
+				questionRepository.saveAll(list);
 
 				Question question1 = questionService.create("질문입니닷", "질문이에요!", user2, 0);
 				Question question2 = questionService.create("질문입니닷22", "질문이에요!22", user2, 0);
@@ -48,6 +61,16 @@ public class NotProd {
 				Answer answer1 = answerService.create(question1, "답변1", user1);
 				Answer answer2 = answerService.create(question1, "답변2", user1);
 
+				List<Answer> answerList = new ArrayList<>();
+				for (int i = 1; i <= 300; i++) {
+					Answer tmp = new Answer();
+					tmp.setContent("테스트 답변%d".formatted(i));
+					tmp.setQuestion(question2);
+					tmp.setAuthor(user3);
+					answerList.add(tmp);
+				}
+
+				answerRepository.saveAll(answerList);
 				}
 			};
 	}

--- a/src/main/java/com/ll/spring_additional/base/initData/NotProd.java
+++ b/src/main/java/com/ll/spring_additional/base/initData/NotProd.java
@@ -37,11 +37,11 @@ public class NotProd {
 			@Transactional
 			public void run(String... args) throws Exception {
 
-				userService.create("admin","admin@test.com", passwordEncoder.encode("1234"));
+				userService.create("admin","admin@test.com", "1234");
 
-				SiteUser user1 = userService.create("user1", "user1@test.com", passwordEncoder.encode("1234"));
-				SiteUser user2 = userService.create("user2", "user2@test.com", passwordEncoder.encode("1234"));
-				SiteUser user3 = userService.create("puar12", "r4560798@naver.com", passwordEncoder.encode("1234"));
+				SiteUser user1 = userService.create("user1", "user1@test.com", "1234");
+				SiteUser user2 = userService.create("user2", "user2@test.com", "1234");
+				SiteUser user3 = userService.create("puar12", "r4560798@naver.com", "1234");
 
 				List<Question> list = new ArrayList<>();
 

--- a/src/main/java/com/ll/spring_additional/boundedContext/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/answer/repository/AnswerRepository.java
@@ -2,9 +2,12 @@ package com.ll.spring_additional.boundedContext.answer.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.spring_additional.boundedContext.answer.entity.Answer;
+import com.ll.spring_additional.boundedContext.question.entity.Question;
 import com.ll.spring_additional.boundedContext.user.entity.SiteUser;
 
 public interface AnswerRepository extends JpaRepository<Answer, Integer> {
@@ -14,4 +17,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Integer> {
 	List<Answer> findTop5ByAuthorOrderByCreateDateDesc(SiteUser user);
 
 	List<Answer> findTop15ByOrderByCreateDateDesc();
+
+	Page<Answer> findAllByQuestion(Question question, Pageable pageable);
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/answer/repository/AnswerRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.ll.spring_additional.boundedContext.answer.entity.Answer;
 import com.ll.spring_additional.boundedContext.question.entity.Question;
@@ -19,4 +21,10 @@ public interface AnswerRepository extends JpaRepository<Answer, Integer> {
 	List<Answer> findTop15ByOrderByCreateDateDesc();
 
 	Page<Answer> findAllByQuestion(Question question, Pageable pageable);
+
+	@Query("SELECT e "
+		+ "FROM Answer e "
+		+ "WHERE e.question = :question "
+		+ "ORDER BY SIZE(e.voters) DESC, e.createDate")
+	Page<Answer> findAllByQuestionOrderByVoter(@Param("question") Question question, Pageable pageable);
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/answer/service/AnswerService.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/answer/service/AnswerService.java
@@ -1,17 +1,19 @@
 package com.ll.spring_additional.boundedContext.answer.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.spring_additional.base.exception.DataNotFoundException;
-import com.ll.spring_additional.boundedContext.answer.repository.AnswerRepository;
 import com.ll.spring_additional.boundedContext.answer.entity.Answer;
+import com.ll.spring_additional.boundedContext.answer.repository.AnswerRepository;
 import com.ll.spring_additional.boundedContext.question.entity.Question;
 import com.ll.spring_additional.boundedContext.user.entity.SiteUser;
 
@@ -23,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class AnswerService {
 
 	private final AnswerRepository answerRepository;
-
 
 	@Transactional
 	public Answer create(Question question, String content, SiteUser author) {
@@ -73,9 +74,25 @@ public class AnswerService {
 		return answerRepository.findTop15ByOrderByCreateDateDesc();
 	}
 
-	public Page<Answer> getAnswerPage(Question question, int page) {
-		Pageable pageable = PageRequest.of(page, 10); // 페이지네이션 정보
-		return answerRepository.findAllByQuestion(question, pageable);
+	public Page<Answer> getAnswerPage(Question question, int page, String sort) {
+		Pageable pageable;
 
+		// 최신순
+		if (sort.equals("createDate")) {
+			List<Sort.Order> sorts = new ArrayList<>();
+			sorts.add(Sort.Order.desc("createDate"));
+			pageable = PageRequest.of(page, 10, Sort.by(sorts)); //페이지 번호, 개수
+			return answerRepository.findAllByQuestion(question, pageable);
+		}
+
+		// 추천순, 기본
+		else {
+			pageable = PageRequest.of(page, 10); // 페이지네이션 정보
+			// 추천순 : 10개에 페이지정보만 주면 알아서
+			if (sort.equals("voter"))
+				return answerRepository.findAllByQuestionOrderByVoter(question, pageable);
+			// 기본
+			return answerRepository.findAllByQuestion(question, pageable);
+		}
 	}
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/answer/service/AnswerService.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/answer/service/AnswerService.java
@@ -3,6 +3,9 @@ package com.ll.spring_additional.boundedContext.answer.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,5 +71,11 @@ public class AnswerService {
 
 	public List<Answer> getAnswerTop15Latest() {
 		return answerRepository.findTop15ByOrderByCreateDateDesc();
+	}
+
+	public Page<Answer> getAnswerPage(Question question, int page) {
+		Pageable pageable = PageRequest.of(page, 10); // 페이지네이션 정보
+		return answerRepository.findAllByQuestion(question, pageable);
+
 	}
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/question/controller/QuestionController.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/question/controller/QuestionController.java
@@ -39,7 +39,8 @@ public class QuestionController {
 	private final AnswerService answerService;
 
 	@GetMapping("/list/{type}")
-	public String list(Model model, @PathVariable String type, @RequestParam(value = "page", defaultValue = "0") int page
+	public String list(Model model, @PathVariable String type,
+		@RequestParam(value = "page", defaultValue = "0") int page
 		, @RequestParam(value = "kw", defaultValue = "") String kw) {
 		int category = switch (type) {
 			case "qna" -> QuestionEnum.QNA.getStatus();
@@ -97,9 +98,10 @@ public class QuestionController {
 	}
 
 	@GetMapping("/detail/{id}")
-	public String detail(Model model, @PathVariable Integer id, AnswerForm answerForm, @RequestParam(defaultValue = "0") int page) {
+	public String detail(Model model, @PathVariable Integer id, AnswerForm answerForm,
+		@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "") String sort) {
 		Question question = questionService.getQuestion(id);
-		Page<Answer> paging = answerService.getAnswerPage(question, page);
+		Page<Answer> paging = answerService.getAnswerPage(question, page, sort);
 		model.addAttribute("question", question);
 		model.addAttribute("paging", paging);
 		return "question/question_detail";
@@ -133,7 +135,8 @@ public class QuestionController {
 
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/create/{type}")
-	public String questionCreate(@Valid QuestionForm questionForm, @PathVariable String type, BindingResult bindingResult, Principal principal) {
+	public String questionCreate(@Valid QuestionForm questionForm, @PathVariable String type,
+		BindingResult bindingResult, Principal principal) {
 		if (bindingResult.hasErrors()) {
 			return "question/question_form";
 		}
@@ -152,14 +155,15 @@ public class QuestionController {
 
 	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/modify/{id}")
-	public String questionModify(QuestionForm questionForm, @PathVariable("id") Integer id, Principal principal, Model model) {
+	public String questionModify(QuestionForm questionForm, @PathVariable("id") Integer id, Principal principal,
+		Model model) {
 		Question question = questionService.getQuestion(id);
 		if (!question.getAuthor().getUsername().equals(principal.getName())) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "수정권한이 없습니다.");
 		}
 
 		switch (question.getCategoryAsEnum()) {
-			case QNA-> model.addAttribute("boardName", "질문과답변 수정");
+			case QNA -> model.addAttribute("boardName", "질문과답변 수정");
 			case FREE -> model.addAttribute("boardName", "자유게시판 수정");
 			case BUG -> model.addAttribute("boardName", "버그및건의 수정");
 			default -> throw new RuntimeException("올바르지 않은 접근입니다.");

--- a/src/main/java/com/ll/spring_additional/boundedContext/question/controller/QuestionController.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/question/controller/QuestionController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.ll.spring_additional.boundedContext.answer.entity.Answer;
 import com.ll.spring_additional.boundedContext.answer.form.AnswerForm;
 import com.ll.spring_additional.boundedContext.answer.service.AnswerService;
 import com.ll.spring_additional.boundedContext.question.entity.Question;
@@ -35,7 +36,6 @@ import lombok.RequiredArgsConstructor;
 public class QuestionController {
 	private final QuestionService questionService;
 	private final UserService userService;
-
 	private final AnswerService answerService;
 
 	@GetMapping("/list/{type}")
@@ -97,9 +97,11 @@ public class QuestionController {
 	}
 
 	@GetMapping("/detail/{id}")
-	public String detail(Model model, @PathVariable Integer id, AnswerForm answerForm) {
+	public String detail(Model model, @PathVariable Integer id, AnswerForm answerForm, @RequestParam(defaultValue = "0") int page) {
 		Question question = questionService.getQuestion(id);
+		Page<Answer> paging = answerService.getAnswerPage(question, page);
 		model.addAttribute("question", question);
+		model.addAttribute("paging", paging);
 		return "question/question_detail";
 	}
 

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -46,7 +46,7 @@
     <h5 class="border-bottom my-3 py-2"
         th:text="|${#lists.size(question.answerList)}개의 답변이 있습니다.|"></h5>
     <!-- 답변 반복 시작 -->
-    <div th:id="|answer_${answer.id}|" class="card my-3" th:each="answer : ${question.answerList}">
+    <div th:id="|answer_${answer.id}|" class="card my-3" th:each="answer : ${paging}">
         <div class="card-body">
             <div class="card-text" th:utext="${@commonUtil.markdown(answer.content)}"></div>
             <div class="d-flex justify-content-end">
@@ -83,6 +83,41 @@
         </div>
     </div>
     <!-- 답변 반복 끝  -->
+    <!-- 답변 페이징처리 시작 -->
+    <div th:if="${!paging.isEmpty()}" th:with="queryStrBase = '?kw=' + ${param.kw != null ? param.kw : ''}">
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${paging.number==0} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{|${queryStrBase}&page=0|}">
+                    <span>처음</span>
+                </a>
+            </li>
+            <li class="page-item" th:classappend="${!paging.hasPrevious} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{|${queryStrBase}&page=${paging.number-1}|}">
+                    <span>이전</span>
+                </a>
+            </li>
+            <li th:each="page: ${#numbers.sequence(0, paging.totalPages-1)}"
+                th:if="${page >= paging.number-5 and page <= paging.number+5}"
+                th:classappend="${page == paging.number} ? 'active'"
+                class="page-item">
+                <a th:text="${page}" class="page-link" th:href="@{|${queryStrBase}&page=${page}|}"></a>
+            </li>
+            <li class="page-item" th:classappend="${!paging.hasNext} ? 'disabled'">
+                <a class="page-link" th:href="@{|${queryStrBase}&page=${paging.number+1}|}">
+                    <span>다음</span>
+                </a>
+            </li>
+            <li class="page-item" th:classappend="${paging.number==(paging.totalPages-1)} ? 'disabled'">
+                <a class="page-link"
+                   th:href="@{|${queryStrBase}&page=${paging.totalPages-1}|}">
+                    <span>끝</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+    <!-- 페이징처리 끝 -->
     <!-- 답변 작성 -->
     <form th:action="@{|/answer/create/${question.id}|}" th:object="${answerForm}" method="post" class="my-3">
         <div th:replace="~{common/form_errors :: formErrorsFragment}"></div>

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -43,8 +43,16 @@
         </div>
     </div>
     <!-- 답변의 갯수 표시 -->
+    <div class="d-flex justify-content-between align-items-baseline">
     <h5 class="border-bottom my-3 py-2"
-        th:text="|${#lists.size(question.answerList)}개의 답변이 있습니다.|"></h5>
+        th:text="|${#lists.size(question.answerList)}개의 답변이 있습니다.|">
+    </h5>
+        <div>
+            <span>답변 정렬 :</span>
+            <a class ="btn btn-primary flex-shrink-1" th:classappend="${param.sort==createDate} ? 'active'" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
+            <a class ="btn btn-primary flex-shrink-1" th:classappend="${param.sort==voter} ? 'active'" th:href="@{|?sort=voter&page=${paging.number}|}">호감순</a>
+        </div>
+    </div>
     <!-- 답변 반복 시작 -->
     <div th:id="|answer_${answer.id}|" class="card my-3" th:each="answer : ${paging}">
         <div class="card-body">
@@ -84,7 +92,7 @@
     </div>
     <!-- 답변 반복 끝  -->
     <!-- 답변 페이징처리 시작 -->
-    <div th:if="${!paging.isEmpty()}" th:with="queryStrBase = '?kw=' + ${param.kw != null ? param.kw : ''}">
+    <div th:if="${!paging.isEmpty()}" th:with="queryStrBase = '?sort=' + ${param.sort != null ? param.sort : ''}">
         <ul class="pagination justify-content-center">
             <li class="page-item" th:classappend="${paging.number==0} ? 'disabled'">
                 <a class="page-link"

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -54,7 +54,7 @@
                     <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
                 </li>
                 <li class="nav-item" th:classappend="${param.sort.equals('voter')} ? 'active'">
-                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=voter&page=${paging.number}|}">호감순</a>
+                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=voter&page=${paging.number}|}">추천순</a>
                 </li>
             </ul>
         </div>

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -50,11 +50,11 @@
         <div>
             <ul class="nav d-flex align-items-baseline gap-2">
                 <span>정렬 기준</span>
-                <li class="nav-item" th:classappend="${param.sort.equals('createDate')} ? 'active'">
-                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
+                <li class="nav-item">
+                    <a class="nav-link btn btn-primary text-white" th:classappend="${#strings.equals(param.sort, 'createDate')} ? 'active'" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
                 </li>
-                <li class="nav-item" th:classappend="${param.sort.equals('voter')} ? 'active'">
-                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=voter&page=${paging.number}|}">추천순</a>
+                <li class="nav-item">
+                    <a class="nav-link btn btn-primary text-white" th:classappend="${#strings.equals(param.sort, 'voter')} ? 'active'" th:href="@{|?sort=voter&page=${paging.number}|}">추천순</a>
                 </li>
             </ul>
         </div>

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -48,9 +48,15 @@
         th:text="|${#lists.size(question.answerList)}개의 답변이 있습니다.|">
     </h5>
         <div>
-            <span>답변 정렬 :</span>
-            <a class ="btn btn-primary flex-shrink-1" th:classappend="${param.sort==createDate} ? 'active'" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
-            <a class ="btn btn-primary flex-shrink-1" th:classappend="${param.sort==voter} ? 'active'" th:href="@{|?sort=voter&page=${paging.number}|}">호감순</a>
+            <ul class="nav d-flex align-items-baseline gap-2">
+                <span>정렬 기준</span>
+                <li class="nav-item" th:classappend="${param.sort.equals('createDate')} ? 'active'">
+                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=createDate&page=${paging.number}|}">최신순</a>
+                </li>
+                <li class="nav-item" th:classappend="${param.sort.equals('voter')} ? 'active'">
+                    <a class="nav-link btn btn-primary text-white" th:href="@{|?sort=voter&page=${paging.number}|}">호감순</a>
+                </li>
+            </ul>
         </div>
     </div>
     <!-- 답변 반복 시작 -->


### PR DESCRIPTION
[점프투스프링부트 3-15 추가기능](https://wikidocs.net/162833)

일곱번째로 답변 페이징, 정렬 기능을 구현했습니다.

- **src/main/java/com/ll/spring_additional/base/initData/NotProd.java**
  - [x] JDBC 배치쓰기를 적용하기 위해 리스트를 활용하였고, 초기 데이터 초기화 속도 증가 시켰습니다.

- **src/main/java/com/ll/spring_additional/boundedContext/answer/repository/AnswerRepository.java**
  - [x] findAllByQuestion 메서드를 통해 페이지에 해당하는 수만 가져옵니다.
  - [x] findAllByQuestionOrderByVoter 메서드를 통해 추천 수에 따라 정렬해서 가져옵니다(List<Sort.Order> sorts 에는 속성만 들어갈 수 있어 별도의 JPQL이나 QueryDsl이 필요합니다.)

- **src/main/java/com/ll/spring_additional/boundedContext/answer/service/AnswerService.java**
  - [x] getAnswerPage 메서드를 통해 sort값에 따른 분기를 진행합니다. "return answerRepository.findAllByQuestion(question, pageable);" 코드가 중복되는데, 추후 switch문 도입 등 개선이 필요합니다.

- **src/main/resources/templates/question/question_detail.html**
  - 현재 있는 페이지 번호는 paging.number로 알 수 있어 정렬 시 기준을 적용 시킬 수 있습니다.
  - param.sort로 페이지 이동 전 파라미터로 sort 값을 가져와 페이지 이동 버튼에 넣어놨기에, 페이지 이동 시 정렬 조건이 유지됩니다

Close #14 


