### PR TITLE
리팩토링 : XSS 공격 대비 및 불필요 코드 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
     implementation 'org.commonmark:commonmark:0.21.0'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.20.0' // 테이블 관련 추가 설정
+    implementation 'org.commonmark:commonmark-ext-gfm-strikethrough:0.21.0' // 취소선 관련 추가 설정
+    implementation 'com.atlassian.commonmark:commonmark-ext-task-list-items:0.15.0' // task 관련 추가 설정
+
+    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/com/ll/spring_additional/base/security/SecurityConfig.java
+++ b/src/main/java/com/ll/spring_additional/base/security/SecurityConfig.java
@@ -1,5 +1,16 @@
 package com.ll.spring_additional.base.security;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+
+import org.commonmark.ext.task.list.items.TaskListItemsExtension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -8,7 +19,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration // 스프링 환경설정 파일
 @EnableWebSecurity // 모든 요청 URL이 스프링 시큐리티의 제어를 받도록 -> 내부적으로 시큐리티 필터체인 동작
@@ -41,5 +51,29 @@ public class SecurityConfig {
 	@Bean
 	PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	// 마크다운 렌더링 렌더러 및 파서 빈 등록
+	@Bean
+	HtmlRenderer htmlRenderer(List<Extension> extensions) {
+		return HtmlRenderer.builder()
+			.extensions(extensions)
+			.build();
+	}
+
+	@Bean
+	Parser parser(List<Extension> extensions) {
+		return Parser.builder()
+			.extensions(extensions)
+			.build();
+	}
+
+	@Bean
+	List<Extension> markdownExtensions() {
+		return Arrays.asList(
+			TablesExtension.create(),
+			StrikethroughExtension.create(),
+			TaskListItemsExtension.create()
+		);
 	}
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/answer/entity/Answer.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/answer/entity/Answer.java
@@ -6,6 +6,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -66,5 +68,6 @@ public class Answer {
 
 	@OneToMany(mappedBy = "answer", cascade = {CascadeType.REMOVE})
 	@ToString.Exclude
+	@LazyCollection(LazyCollectionOption.EXTRA) // commentList.size(); 함수가 실행될 때 SELECT COUNT 실행
 	private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/ll/spring_additional/boundedContext/question/entity/Question.java
+++ b/src/main/java/com/ll/spring_additional/boundedContext/question/entity/Question.java
@@ -111,6 +111,7 @@ public class Question {
 
 	@OneToMany(mappedBy = "question", cascade = {CascadeType.REMOVE})
 	@ToString.Exclude
+	@LazyCollection(LazyCollectionOption.EXTRA) // commentList.size(); 함수가 실행될 때 SELECT COUNT 실행
 	private List<Comment> comments = new ArrayList<>();
 
 }

--- a/src/main/java/com/ll/spring_additional/standard/util/CommonUtil.java
+++ b/src/main/java/com/ll/spring_additional/standard/util/CommonUtil.java
@@ -3,14 +3,37 @@ package com.ll.spring_additional.standard.util;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class CommonUtil {
+	private final Parser parser;
+	private final HtmlRenderer renderer;
+
 	public String markdown(String markdown) {
-		Parser parser = Parser.builder().build();
 		Node document = parser.parse(markdown);
-		HtmlRenderer renderer = HtmlRenderer.builder().build();
-		return renderer.render(document);
+		String html = renderer.render(document);
+
+		System.out.println("Converted HTML: " + html);
+
+		// Sanitize HTML
+		PolicyFactory policy = new HtmlPolicyBuilder()
+			.allowElements("h1", "h2", "h3", "p", "b", "i", "em", "strong", "img", "a", "ul", "ol", "li", "table", "thead", "tbody", "tr", "th", "td", "del", "blockquote", "code", "pre", "input", "hr")
+			.allowUrlProtocols("https", "http")
+			.allowAttributes("href", "target").onElements("a")
+			.allowAttributes("src", "alt").onElements("img")
+			.allowAttributes("type", "checked", "disabled").onElements("input")
+			.allowAttributes("border", "cellspacing", "cellpadding").onElements("table")
+			.requireRelNofollowOnLinks()
+			.toFactory();
+
+		String safeHtml = policy.sanitize(html);
+		System.out.println("After sanitize: " + safeHtml);
+		return safeHtml; // Return the sanitized HTML
 	}
 }

--- a/src/main/resources/static/markdown.css
+++ b/src/main/resources/static/markdown.css
@@ -1,0 +1,48 @@
+table {
+    border-collapse: collapse;  /* 테두리 */>
+}
+
+thead {
+    background-color: #91c0fd;
+    font-weight: bold;
+    color: white;
+    padding: 12px;
+    text-align: center;
+}
+
+th, td {
+    padding: 12px;
+    border: 3px solid #91c0fd;
+}
+ /* 인용 */
+blockquote {
+    /* 왼쪽 경계선 */
+    border-left: 4px solid #cccccc;
+    /* 들여 쓰기와 여백 */
+    padding-left: 20px;
+    margin-left: 0;
+    /* 글꼴 속성 (기울어짐, 색상 등) */
+    font-style: italic;
+    color: #666666;
+}
+
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
+img {
+    max-width: 100%;
+}
+
+/*code {*/
+/*    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;*/
+/*    font-size: 0.9rem;*/
+/*    background-color: #f5f5f5;*/
+/*    color: #444;*/
+/*    padding: 0.1rem 0.5rem;*/
+/*    border-radius: 0.2rem;*/
+/*    white-space: nowrap;*/
+/*    overflow-x: auto;*/
+/*    line-height: 1.2;*/
+/*}*/

--- a/src/main/resources/static/markdown.css
+++ b/src/main/resources/static/markdown.css
@@ -34,15 +34,3 @@ a {
 img {
     max-width: 100%;
 }
-
-/*code {*/
-/*    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;*/
-/*    font-size: 0.9rem;*/
-/*    background-color: #f5f5f5;*/
-/*    color: #444;*/
-/*    padding: 0.1rem 0.5rem;*/
-/*    border-radius: 0.2rem;*/
-/*    white-space: nowrap;*/
-/*    overflow-x: auto;*/
-/*    line-height: 1.2;*/
-/*}*/

--- a/src/main/resources/templates/comment/answer_comment.html
+++ b/src/main/resources/templates/comment/answer_comment.html
@@ -27,12 +27,12 @@
     <!-- 댓글 개수 갱신용 -->
     <div id="new_total_answer_comments" th:if="${totalCount !=null}" th:text="${totalCount}" style="display: none;"></div>
     <div th:if="${totalCount ==null}" th:text="${totalCount}"style="display: none;">0</div>
-    <ul>
-      <li class="nav-link d-flex flex-column gap-2" th:each="comment : ${answerCommentPaging}" th:if="${comment.parent == null}">
+
+      <div class="nav-link d-flex flex-column gap-2" th:each="comment : ${answerCommentPaging}" th:if="${comment.parent == null}">
         <div class="card-body bg-white rounded shadow-lg">
           <a th:id="|answer_comment_${comment.id}|"></a>
           <div class="d-flex align-items-baseline gap-2">
-            <p th:text="${comment.writer.username}" class="text-primary"></p>
+            <p th:text="${comment.writer.username}" class="text-primary" style="white-space: pre-wrap;"></p>
             <!-- 비밀댓글 표시 자물쇠-->
             <span class="badge text-bg-success" th:if="${comment.secret}">
               <i class="fa-solid fa-lock" style="color: #ffffff;"></i>
@@ -133,8 +133,8 @@
         </div>
 
         <!-- 대댓글 출력-->
-        <ul class="ml-8 space-y-2">
-          <li th:each="childComment, childIndex : ${comment.children}">
+        <div class="ml-8 space-y-2">
+          <div th:each="childComment, childIndex : ${comment.children}">
             <div class="p-4">
               <a th:id="|answer_comment_${childComment.id}|"></a>
               <div class="d-flex align-items-baseline gap-2">
@@ -145,7 +145,7 @@
                 </span>
               </div>
               <div class="d-flex justify-content-between">
-                <p th:text="${childComment.content}" th:if="${!childComment.deleted and !childComment.secret}"></p>
+                <p th:text="${childComment.content}" style="white-space: pre-wrap;" th:if="${!childComment.deleted and !childComment.secret}"></p>
                 <p class="text-body-tertiary" th:if="${childComment.deleted}"> 삭제된 댓글입니다.</p>
                 <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 대댓글 작성자 or 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
                 <div sec:authorize="isAuthenticated()">
@@ -218,10 +218,9 @@
                 </button>
               </div>
             </div>
-          </li>
-        </ul>
-      </li>
-    </ul>
+          </div>
+        </div>
+      </div>
     <!-- 댓글 페이징처리 시작 -->
     <div th:if="${!answerCommentPaging.isEmpty()}">
       <ul class="pagination justify-content-center">

--- a/src/main/resources/templates/comment/answer_comment.html
+++ b/src/main/resources/templates/comment/answer_comment.html
@@ -39,12 +39,12 @@
             </span>
           </div>
           <div class="d-flex justify-content-between">
-            <p th:text="${comment.content}" th:if="${!comment.deleted and !comment.secret}"></p>
+            <p th:text="${comment.content}" style="white-space: pre-wrap;"  th:if="${!comment.deleted and !comment.secret}"></p>
             <p class="text-body-tertiary" th:if="${comment.deleted}"> 삭제된 댓글입니다.</p>
             <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
             <div sec:authorize="isAuthenticated()">
               <p class="text-lg font-bold" th:if="${comment.secret and ((comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}"
-              th:text="${comment.content}"></p>
+              th:text="${comment.content}" style="white-space: pre-wrap;" ></p>
               <p class="text-lg font-bold"
                  th:if="${comment.secret and !((comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}">
                 비밀 댓글입니다.</p>
@@ -150,7 +150,7 @@
                 <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 대댓글 작성자 or 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
                 <div sec:authorize="isAuthenticated()">
                   <p class="text-lg font-bold" th:if="${childComment.secret and ((childComment.writer.username == #authentication.getPrincipal().getUsername()) or (comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}"
-                     th:text="${childComment.content}"></p>
+                     th:text="${childComment.content}" style="white-space: pre-wrap;" ></p>
                   <p class="text-lg font-bold"
                      th:if="${childComment.secret and !((childComment.writer.username == #authentication.getPrincipal().getUsername()) or (comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}">
                     비밀 댓글입니다.</p>
@@ -631,19 +631,6 @@
           console.log("요청 실패", err);
         }
       });
-    }
-
-    function Answer_CommentForm__submit(form) {
-      // username 이(가) 올바른지 체크
-
-      form.commentContents.value = form.commentContents.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
-
-      if (form.commentContents.value.length === 0) {
-        alert('내용을 입력해주세요');
-        form.commentContents.focus();
-        return;
-      }
-      form.submit(); // 폼 발송
     }
   </script>
 

--- a/src/main/resources/templates/comment/question_comment.html
+++ b/src/main/resources/templates/comment/question_comment.html
@@ -43,7 +43,7 @@
             <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
             <div sec:authorize="isAuthenticated()">
               <p class="text-lg font-bold" th:if="${comment.secret and ((comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}"
-              th:text="${comment.content}"></p>
+              th:text="${comment.content}" style="white-space: pre-wrap;" ></p>
               <p class="text-lg font-bold"
                  th:if="${comment.secret and !((comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}">
                 비밀 댓글입니다.</p>
@@ -149,7 +149,7 @@
                 <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 대댓글 작성자 or 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
                 <div sec:authorize="isAuthenticated()">
                   <p class="text-lg font-bold" th:if="${childComment.secret and ((childComment.writer.username == #authentication.getPrincipal().getUsername()) or (comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}"
-                     th:text="${childComment.content}"></p>
+                     th:text="${childComment.content}" style="white-space: pre-wrap;" ></p>
                   <p class="text-lg font-bold"
                      th:if="${childComment.secret and !((childComment.writer.username == #authentication.getPrincipal().getUsername()) or (comment.writer.username == #authentication.getPrincipal().getUsername()) or (question.author.username == #authentication.getPrincipal().getUsername()) or (#authentication.principal.username eq 'admin'))}">
                     비밀 댓글입니다.</p>
@@ -621,19 +621,6 @@
       });
     }
 
-
-    function CommentForm__submit(form) {
-      // username 이(가) 올바른지 체크
-
-      form.commentContents.value = form.commentContents.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
-
-      if (form.commentContents.value.length === 0) {
-        alert('내용을 입력해주세요');
-        form.commentContents.focus();
-        return;
-      }
-      form.submit(); // 폼 발송
-    }
   </script>
 
 </main>

--- a/src/main/resources/templates/comment/question_comment.html
+++ b/src/main/resources/templates/comment/question_comment.html
@@ -27,8 +27,7 @@
     <div id="new_total_question_comments" th:if="${totalCount !=null}" th:text="${totalCount}" style="display: none;"></div>
     <div th:if="${totalCount ==null}" th:text="${totalCount}"style="display: none;">0</div>
     <!-- 댓글 출력 부분-->
-    <ul>
-      <li class="nav-link d-flex flex-column gap-2" th:each="comment : ${questionCommentPaging}" th:if="${comment.parent == null}">
+      <div class="nav-link d-flex flex-column gap-2" th:each="comment : ${questionCommentPaging}" th:if="${comment.parent == null}">
         <div class="card-body bg-white rounded shadow-lg">
           <a th:id="|question_comment_${comment.id}|"></a>
           <div class="d-flex align-items-baseline gap-2">
@@ -39,7 +38,7 @@
             </span>
           </div>
           <div class="d-flex justify-content-between">
-            <p th:text="${comment.content}" th:if="${!comment.deleted and !comment.secret}"></p>
+            <p th:text="${comment.content}" style="white-space: pre-wrap;" th:if="${!comment.deleted and !comment.secret}"></p>
             <p class="text-body-tertiary" th:if="${comment.deleted}"> 삭제된 댓글입니다.</p>
             <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
             <div sec:authorize="isAuthenticated()">
@@ -133,8 +132,8 @@
         </div>
 
         <!-- 대댓글 출력-->
-        <ul class="ml-8 space-y-2">
-          <li th:each="childComment, childIndex : ${comment.children}">
+        <div class="ml-8 space-y-2">
+          <div th:each="childComment, childIndex : ${comment.children}">
             <div class="p-4">
               <a th:id="|comment_${childComment.id}|"></a>
               <div class="d-flex align-items-baseline gap-2">
@@ -145,7 +144,7 @@
                 </span>
               </div>
               <div class="d-flex justify-content-between">
-                <p th:text="${childComment.content}" th:if="${!childComment.deleted and !childComment.secret}"></p>
+                <p th:text="${childComment.content}" style="white-space: pre-wrap;" th:if="${!childComment.deleted and !childComment.secret}"></p>
                 <p class="text-body-tertiary" th:if="${childComment.deleted}"> 삭제된 댓글입니다.</p>
                 <!-- 비밀 댓글 분기 시작, 위 : 로그인 시 대댓글 작성자 or 댓글 작성자 or 질문 작성자 or 관리자일 경우 확인 가능 / 아래 : 로그인 안하면 아에 안보이게-->
                 <div sec:authorize="isAuthenticated()">
@@ -218,10 +217,10 @@
                 </button>
               </div>
             </div>
-          </li>
-        </ul>
-      </li>
-    </ul>
+          </div>
+        </div>
+      </div>
+
     <!-- 댓글 페이징처리 시작 -->
     <div th:if="${!questionCommentPaging.isEmpty()}">
       <ul class="pagination justify-content-center">

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -25,16 +25,6 @@
     color:inherit;
     text-decoration:inherit;
     }
-
-    ul, li {
-        /* 앞에 점 없애기 */
-        list-style:none;
-        /* 안쪽 여백 제거 */
-        padding:0;
-        /* 바깥쪽 여백 제거 */
-        margin:0;
-    }
-
     </style>
 
 

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -1,10 +1,20 @@
 <html layout:decorate="~{common/layout}">
+<head>
+    <!-- 마크다운 css -->
+    <link rel="stylesheet" type="text/css" th:href="@{/markdown.css}">
+    <!-- highlight.JS  -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js" integrity="sha512-rdhY3cbXURo13l/WU9VlaRyaIYeJ/KBakckXIvJNAQde8DgpOmE+eZf7ha4vdqVjTtwQt69bD2wH2LXob/LB7Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        hljs.highlightAll();
+    </script>
+</head>
 <main layout:fragment="content" class="container my-3" id="questionDetail">
     <!-- 질문 -->
     <h2 class="border-bottom py-2" th:text="${question.subject}"></h2>
     <div class="card my-3">
         <div class="card-body">
-            <div class="card-text" th:utext="${@commonUtil.markdown(question.content)}"></div>
+            <div class="card-text" th:utext="${@commonUtil.markdown(question.content)}" style="white-space: pre-wrap;"></div>
             <div class="d-flex justify-content-end">
                 <div th:if="${question.modifyDate != null}" class="badge bg-light text-dark p-2 text-start mx-3">
                     <div class="mb-2">modified at</div>
@@ -72,7 +82,7 @@
     <!-- 답변 반복 시작 -->
     <div th:id="|answer_${answer.id}|" class="card my-3" th:each="answer : ${paging}">
         <div class="card-body">
-            <div class="card-text" th:utext="${@commonUtil.markdown(answer.content)}"></div>
+            <div class="card-text" th:utext="${@commonUtil.markdown(answer.content)}" style="white-space: pre-wrap;"></div>
             <div class="d-flex justify-content-end">
                 <div th:if="${answer.modifyDate != null}" class="badge bg-light text-dark p-2 text-start mx-3">
                     <div class="mb-2">modified at</div>
@@ -168,7 +178,25 @@
 
         window.onload = function () {
             checkQuestionRead(); // html 로드 시 바로 Ajax 요청
+            addClassInCode();
         };
+
+        // code 태그가 있다면 pre태그와 markdown-body 클래스 추가
+        function addClassInCode() {
+            const codeElements = document.querySelectorAll('code');
+
+            codeElements.forEach(codeElement => {
+                if (!codeElement.parentElement.classList.contains('markdown-body')) {
+                    const wrapper = document.createElement('div');
+                    wrapper.classList.add('markdown-body');
+
+                    const pre = document.createElement('pre');
+                    codeElement.parentElement.insertBefore(wrapper, codeElement);
+                    wrapper.appendChild(pre);
+                    pre.appendChild(codeElement);
+                }
+            });
+        }
 
         // 로컬스토리지에 해당 게시글 읽은적이 있는지 검사
         function checkIdInLocalStorage(id) {

--- a/src/main/resources/templates/question/question_detail.html
+++ b/src/main/resources/templates/question/question_detail.html
@@ -181,20 +181,24 @@
             addClassInCode();
         };
 
-        // code 태그가 있다면 pre태그와 markdown-body 클래스 추가
         function addClassInCode() {
+            // 코드 요소를 모두 선택합니다.
             const codeElements = document.querySelectorAll('code');
 
+            // 각 코드 요소마다 실행합니다.
             codeElements.forEach(codeElement => {
-                if (!codeElement.parentElement.classList.contains('markdown-body')) {
-                    const wrapper = document.createElement('div');
-                    wrapper.classList.add('markdown-body');
 
-                    const pre = document.createElement('pre');
-                    codeElement.parentElement.insertBefore(wrapper, codeElement);
-                    wrapper.appendChild(pre);
-                    pre.appendChild(codeElement);
+                // 코드 요소 바로 앞에 있는 요소가 이미 pre 태그인 경우, 추가 작업을 하지 않습니다.
+                const prevElement = codeElement.previousElementSibling;
+                if (prevElement && prevElement.tagName.toLowerCase() === 'pre') {
+                    return;
                 }
+
+                // pre 태그를 생성하고, 코드 요소를 해당 pre 태그의 자식 요소로 추가합니다.
+                const pre = document.createElement('pre');
+                const codeParent = codeElement.parentNode;
+                codeParent.replaceChild(pre, codeElement);
+                pre.appendChild(codeElement);
             });
         }
 


### PR DESCRIPTION
구현한 기능 중 **마크다운 에디터** 기능이 **th:utext** 타임리프 문법을 그대로 사용하기에, XSS 공격에 취약했습니다.

이를 해결하고자 common mark와 java-html-sanitizer를 같이 사용하였습니다.

commonmark에서는 일부 HTML 태그의 경우 extension 의존성을 주입해야 sanitizer에 적용 가능하여 각각 issue와 파일을 찾아가며 의존성 버전을 맞췄습니다.
- [CommonMark](https://github.com/commonmark/commonmark-java)

개선 사항
- 마크다운 문법에 해당하는 것들을 모두 허용 시키고 나머지는 렌더링을 하지 않으며 XSS 공격에 방어할 수 있었습니다.
- 또한 렌더링에 필요한 객체들을 빈으로 등록하여 페이지 렌더링 할 때마다 생성하지 않도록 하였습니다. 
- 사용하지 않는 코드를 제거하였습니다.

**src/main/resources/static/markdown.css**
- 일부 태그의 경우 태그만 생기고 스타일이 적용되지 않아 적용시켰습니다.

**src/main/resources/templates/question/question_detail.html**
- 마크다운 Code 태그 적용하면 글꼴이 빨간색에 가운데 정렬이 기본값이였습니다.
- 마크다운 스타일과 유사하게 하기 위해 highlight 라이브러리를 적용시켰습니다.
- 아래의 형태여야 적용되기에, HTML 파일 처음에 렌더링 될 때 태그 추가하도록 메서드 구현했습니다.
```HTML
<pre><code> </pre></code>
``` 

** Answer / Question
- Question Detail 페이지 보여질 때 댓글 개수를 보여줄 때 댓글 전체를 다 가져와서 보여줍니다.
- 댓글 조회를 누르지 않으면 개수만 필요하기에 Count쿼리가 실행 되도록 수정하였습니다.
  - @LazyCollection(LazyCollectionOption.EXTRA) 옵션 활용

Close #20 

